### PR TITLE
Add X-Ray OTLP sink configuration and tests

### DIFF
--- a/data-prepper-plugins/xray-otlp-sink/README.md
+++ b/data-prepper-plugins/xray-otlp-sink/README.md
@@ -8,6 +8,42 @@ For information on usage, see the forthcoming documentation in the [Data Prepper
 
 A sample pipeline configuration will be added once the plugin is ready for testing.
 
+### Configuration Options
+
+#### aws (Required)
+Configuration options for AWS authentication and region settings.
+
+* `region` (Required): The AWS region where X-Ray service is located
+    * Must be a valid AWS region identifier (e.g., us-east-1, us-west-2)
+    * Cannot be empty
+
+* `sts_role_arn` (Required): AWS STS Role ARN for assuming role-based access
+    * Format: arn:aws:iam::{account}:role/{role-name}
+    * Length must be between 20 and 2048 characters
+
+* `sts_external_id` (Optional): External ID for additional security when assuming an IAM role
+    * Required only if the trust policy requires an external ID
+    * Length must be between 2 and 1224 characters
+
+### Sample Pipeline Configuration
+
+```yaml
+pipeline:
+  source:
+    otel_trace_source:
+      ssl: true
+      
+  buffer:
+    bounded_blocking:
+      buffer_size: 10
+      batch_size: 5
+      
+  sink:
+    - xray-otlp-sink:
+        aws:
+          region: us-west-2
+          sts_role_arn: arn:aws:iam::123456789012:role/XrayRole
+        
 ## Developer Guide
 
 See the [CONTRIBUTING](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md) guide for general information on contributions.

--- a/data-prepper-plugins/xray-otlp-sink/build.gradle
+++ b/data-prepper-plugins/xray-otlp-sink/build.gradle
@@ -8,8 +8,11 @@ plugins {
 }
 
 dependencies {
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
     implementation project(':data-prepper-api')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'software.amazon.awssdk:regions'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.1'

--- a/data-prepper-plugins/xray-otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/XRayOTLPSinkConfig.java
+++ b/data-prepper-plugins/xray-otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/XRayOTLPSinkConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins.sink.xrayotlp;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import org.opensearch.dataprepper.plugins.sink.xrayotlp.configuration.AwsAuthenticationConfiguration;
+
+/**
+ * Configuration class for the X-Ray OTLP sink plugin.
+ * This class defines the configuration options available when setting up
+ * the X-Ray OTLP sink in Data Prepper pipelines.
+ *
+ * @since 2.6
+ */
+public class XRayOTLPSinkConfig {
+    public static final String DEFAULT_AWS_REGION = "us-east-1";
+
+    /**
+     * AWS configuration for X-Ray access.
+     * Contains authentication and region settings required for AWS X-Ray service.
+     * This is a required configuration and must be valid.
+     */
+    @Getter
+    @JsonProperty("aws")
+    @NotNull
+    @Valid
+    AwsAuthenticationConfiguration awsAuthenticationConfiguration;
+}

--- a/data-prepper-plugins/xray-otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/configuration/AwsAuthenticationConfiguration.java
+++ b/data-prepper-plugins/xray-otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/configuration/AwsAuthenticationConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins.sink.xrayotlp.configuration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import software.amazon.awssdk.regions.Region;
+
+import static org.opensearch.dataprepper.plugins.sink.xrayotlp.XRayOTLPSinkConfig.DEFAULT_AWS_REGION;
+
+/**
+ * Configuration class for AWS authentication settings.
+ * Handles region, STS role ARN, and external ID configurations required for AWS service access.
+ *
+ * @since 2.6
+ */
+public class AwsAuthenticationConfiguration {
+    /**
+     * AWS region for X-Ray service.
+     * Must be a valid AWS region identifier (e.g., us-east-1, us-west-2).
+     */
+    @JsonProperty("region")
+    @Size(min = 1, message = "Region cannot be empty string")
+    public String awsRegion = DEFAULT_AWS_REGION;
+
+    /**
+     * AWS STS Role ARN for assuming role-based access.
+     * Format: arn:aws:iam::{account}:role/{role-name}
+     * Length must be between 20 and 2048 characters.
+     */
+    @Getter
+    @JsonProperty("sts_role_arn")
+    @Size(min = 20, max = 2048, message = "awsStsRoleArn length should be between 1 and 2048 characters")
+    public String awsStsRoleArn;
+
+    /**
+     * External ID for additional security when assuming an IAM role.
+     * Required only if the trust policy requires an external ID.
+     * Length must be between 2 and 1224 characters.
+     */
+    @Getter
+    @JsonProperty("sts_external_id")
+    @Size(min = 2, max = 1224, message = "awsStsExternalId length should be between 2 and 1224 characters")
+    public String awsStsExternalId;
+
+    /**
+     * Gets the AWS Region object corresponding to the configured region string.
+     *
+     * @return Region object if awsRegion is set, null otherwise
+     */
+    public Region getAwsRegion() {
+        return awsRegion != null ? Region.of(awsRegion) : null;
+    }
+}

--- a/data-prepper-plugins/xray-otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/AwsAuthenticationConfigurationTest.java
+++ b/data-prepper-plugins/xray-otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/AwsAuthenticationConfigurationTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins.sink.xrayotlp;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.plugins.sink.xrayotlp.configuration.AwsAuthenticationConfiguration;
+import software.amazon.awssdk.regions.Region;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class AwsAuthenticationConfigurationTest {
+
+    @Test
+    void testGetRegion() {
+        final AwsAuthenticationConfiguration config = new AwsAuthenticationConfiguration();
+        config.awsRegion = "us-west-2";
+
+        assertThat(config.getAwsRegion(), notNullValue());
+        assertThat(config.getAwsRegion(), equalTo(Region.US_WEST_2));
+    }
+
+    @Test
+    void testGetStsRoleArn() {
+        final AwsAuthenticationConfiguration config = new AwsAuthenticationConfiguration();
+        final String roleArn = "arn:aws:iam::123456789012:role/MyRole";
+        config.awsStsRoleArn = roleArn;
+
+        assertThat(config.awsStsRoleArn, equalTo(roleArn));
+    }
+
+    @Test
+    void testGetStsExternalId() {
+        final AwsAuthenticationConfiguration config = new AwsAuthenticationConfiguration();
+        final String externalId = "myExternalId";
+        config.awsStsExternalId = externalId;
+
+        assertThat(config.awsStsExternalId, equalTo(externalId));
+    }
+}

--- a/data-prepper-plugins/xray-otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/XRayOTLPSinkConfigTest.java
+++ b/data-prepper-plugins/xray-otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/XRayOTLPSinkConfigTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.opensearch.dataprepper.plugins.sink.xrayotlp;
+
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.plugins.sink.xrayotlp.configuration.AwsAuthenticationConfiguration;
+import software.amazon.awssdk.regions.Region;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class XRayOTLPSinkConfigTest {
+
+    @Test
+    void testGetAwsConfiguration() {
+        final XRayOTLPSinkConfig config = new XRayOTLPSinkConfig();
+        final AwsAuthenticationConfiguration awsConfig = new AwsAuthenticationConfiguration();
+        config.awsAuthenticationConfiguration = awsConfig;
+
+        assertThat(config.awsAuthenticationConfiguration, notNullValue());
+        assertThat(config.awsAuthenticationConfiguration, equalTo(awsConfig));
+    }
+
+    @Test
+    void testGetAwsConfiguration_whenNull() {
+        final XRayOTLPSinkConfig config = new XRayOTLPSinkConfig();
+        assertThat(config.awsAuthenticationConfiguration, is(nullValue()));
+    }
+
+    @Test
+    void testAwsConfiguration_withRegion() {
+        final XRayOTLPSinkConfig config = new XRayOTLPSinkConfig();
+        final AwsAuthenticationConfiguration awsConfig = new AwsAuthenticationConfiguration();
+        awsConfig.awsRegion = "us-west-2";
+        config.awsAuthenticationConfiguration = awsConfig;
+
+        assertThat(config.awsAuthenticationConfiguration.getAwsRegion(), equalTo(Region.US_WEST_2));
+    }
+
+    @Test
+    void testAwsConfiguration_withStsRole() {
+        final XRayOTLPSinkConfig config = new XRayOTLPSinkConfig();
+        final AwsAuthenticationConfiguration awsConfig = new AwsAuthenticationConfiguration();
+        awsConfig.awsStsRoleArn = "arn:aws:iam::123456789012:role/MyRole";
+        config.awsAuthenticationConfiguration = awsConfig;
+
+        assertThat(config.awsAuthenticationConfiguration.awsStsRoleArn,
+                equalTo("arn:aws:iam::123456789012:role/MyRole"));
+    }
+
+    @Test
+    void testAwsConfiguration_withCompleteConfig() {
+        final XRayOTLPSinkConfig config = new XRayOTLPSinkConfig();
+        final AwsAuthenticationConfiguration awsConfig = new AwsAuthenticationConfiguration();
+        awsConfig.awsRegion = "us-west-2";
+        awsConfig.awsStsRoleArn = "arn:aws:iam::123456789012:role/MyRole";
+        awsConfig.awsStsExternalId = "MyExternalId";
+        config.awsAuthenticationConfiguration = awsConfig;
+
+        assertThat(config.awsAuthenticationConfiguration.getAwsRegion(), equalTo(Region.US_WEST_2));
+        assertThat(config.awsAuthenticationConfiguration.awsStsRoleArn,
+                equalTo("arn:aws:iam::123456789012:role/MyRole"));
+        assertThat(config.awsAuthenticationConfiguration.awsStsExternalId, equalTo("MyExternalId"));
+    }
+}


### PR DESCRIPTION
### Description
This PR introduces the following changes:

- Add XRayOTLPSinkConfig class for X-Ray OTLP sink configuration
- Add AwsAuthenticationConfiguration class for AWS-specific settings
- Add unit tests for XRayOTLPSinkConfig and AwsAuthenticationConfiguration
- Update build.gradle with necessary dependencies
- Update README

These changes provide the foundation for configuring the X-Ray OTLP sink
in Data Prepper, allowing users to specify AWS region, STS role ARN,
and external ID for authentication.

The configuration follows Data Prepper's standards and includes proper
validation for required fields and input formats.

### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
