### PR TITLE
Add otlp proto trace output codec

### DIFF
--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoTraceOutputCodec.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoTraceOutputCodec.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.otel.codec;
+
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import org.apache.commons.codec.DecoderException;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.codec.OutputCodec;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.sink.OutputCodecContext;
+import org.opensearch.dataprepper.model.trace.Span;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * OutputCodec for OTLP Traces that encodes Span events into OTLP Protobuf binary format
+ */
+@DataPrepperPlugin(name = "otlp_trace", pluginType = OutputCodec.class)
+public class OTelProtoTraceOutputCodec implements OutputCodec {
+
+    private static final String OTLP_EXTENSION = "otlp";
+    private static final Logger LOG = LoggerFactory.getLogger(OTelProtoTraceOutputCodec.class);;
+
+    private final OTelProtoStandardCodec.OTelProtoEncoder encoder = new OTelProtoStandardCodec.OTelProtoEncoder();
+
+    @Override
+    public void start(OutputStream outputStream, Event event, OutputCodecContext context) {
+        // no-op for OTLP
+    }
+
+    @Override
+    public void writeEvent(Event event, OutputStream outputStream) throws IOException {
+        if (!(event instanceof Span)) {
+            throw new IllegalArgumentException("OtlpTraceOutputCodec only supports Span events");
+        }
+
+        Span span = (Span) event;
+        try {
+            ResourceSpans resourceSpans = encoder.convertToResourceSpans(span);
+            ExportTraceServiceRequest request = ExportTraceServiceRequest.newBuilder()
+                    .addResourceSpans(resourceSpans)
+                    .build();
+
+            outputStream.write(request.toByteArray());
+        } catch (DecoderException e) {
+            LOG.warn("Skipping invalid span with ID [{}] due to decoding error.", span.getSpanId(), e);
+        }
+    }
+
+
+    @Override
+    public void complete(OutputStream outputStream) {
+        // no-op for OTLP
+    }
+
+    @Override
+    public String getExtension() {
+        return OTLP_EXTENSION;
+    }
+}
+

--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoTraceOutputCodecTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OTelProtoTraceOutputCodecTest.java
@@ -1,0 +1,122 @@
+package org.opensearch.dataprepper.plugins.otel.codec;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.sink.OutputCodecContext;
+import org.opensearch.dataprepper.model.trace.DefaultTraceGroupFields;
+import org.opensearch.dataprepper.model.trace.JacksonSpan;
+import org.opensearch.dataprepper.model.trace.Span;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OTelProtoTraceOutputCodecTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String TEST_SPAN_EVENT_JSON_FILE = "test-span-event.json";
+
+    private OTelProtoTraceOutputCodec codec;
+
+    @BeforeEach
+    void setup() {
+        codec = new OTelProtoTraceOutputCodec();
+    }
+
+    private Span buildSpanFromTestFile(String fileName) {
+        try (InputStream inputStream = Objects.requireNonNull(
+                getClass().getClassLoader().getResourceAsStream(fileName))) {
+
+            Map<String, Object> spanMap = OBJECT_MAPPER.readValue(inputStream, new TypeReference<>() {});
+            JacksonSpan.Builder builder = JacksonSpan.builder()
+                    .withTraceId((String) spanMap.get("traceId"))
+                    .withSpanId((String) spanMap.get("spanId"))
+                    .withParentSpanId((String) spanMap.get("parentSpanId"))
+                    .withTraceState((String) spanMap.get("traceState"))
+                    .withName((String) spanMap.get("name"))
+                    .withKind((String) spanMap.get("kind"))
+                    .withDurationInNanos(((Number) spanMap.get("durationInNanos")).longValue())
+                    .withStartTime((String) spanMap.get("startTime"))
+                    .withEndTime((String) spanMap.get("endTime"))
+                    .withTraceGroup((String) spanMap.get("traceGroup"));
+
+            Map<String, Object> traceGroupFieldsMap = (Map<String, Object>) spanMap.get("traceGroupFields");
+            if (traceGroupFieldsMap != null) {
+                builder.withTraceGroupFields(DefaultTraceGroupFields.builder()
+                        .withStatusCode((Integer) traceGroupFieldsMap.getOrDefault("statusCode", 0))
+                        .withEndTime((String) spanMap.get("endTime"))
+                        .withDurationInNanos(((Number) spanMap.get("durationInNanos")).longValue())
+                        .build());
+            }
+
+            return builder.build();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load span from file", e);
+        }
+    }
+
+    @Test
+    void testWriteEvent_withValidSpanFromTestFile_writesSuccessfully() throws Exception {
+        Span span = buildSpanFromTestFile(TEST_SPAN_EVENT_JSON_FILE);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        codec.start(outputStream, span, new OutputCodecContext());
+        codec.writeEvent(span, outputStream);
+        codec.complete(outputStream);
+
+        byte[] bytes = outputStream.toByteArray();
+        assertThat(bytes).isNotEmpty();
+
+        ExportTraceServiceRequest request = ExportTraceServiceRequest.parseFrom(bytes);
+        assertThat(request.getResourceSpansCount()).isGreaterThan(0);
+    }
+
+    @Test
+    void testWriteEvent_withBadTraceId_logsAndSkips() throws Exception {
+        Span span = JacksonSpan.builder()
+                .withTraceId("bad-trace-id") // not valid hex
+                .withSpanId("1234567812345678")
+                .withParentSpanId("")
+                .withName("InvalidSpan")
+                .withKind("INTERNAL")
+                .withTraceGroup("InvalidSpan")
+                .withStartTime("2020-05-24T14:00:00Z")
+                .withEndTime("2020-05-24T14:00:01Z")
+                .withDurationInNanos(1_000_000_000L)
+                .withTraceGroupFields(DefaultTraceGroupFields.builder()
+                        .withStatusCode(0)
+                        .withEndTime("2020-05-24T14:00:01Z")
+                        .withDurationInNanos(1_000_000_000L)
+                        .build())
+                .build();
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        codec.writeEvent(span, outputStream);
+
+        // Since traceId is invalid hex, it will trigger DecoderException
+        assertThat(outputStream.toByteArray()).isEmpty(); // nothing written
+    }
+
+    @Test
+    void testWriteEvent_withNonSpanEvent_throwsException() {
+        JacksonEvent fakeEvent = JacksonEvent.builder()
+                .withEventType("fake")
+                .withData(Map.of("key", "value"))
+                .build();
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        assertThatThrownBy(() -> codec.writeEvent(fakeEvent, outputStream))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("only supports Span");
+    }
+
+}


### PR DESCRIPTION
### Description
Changes: 
* OtelProtoTraceOutputCodec:
A new OutputCodec implementation that serializes Span events into OTLP-compatible ExportTraceServiceRequest Protobuf messages.

* OtelProtoTraceOutputCodecTest:
Unit tests validating the codec’s behavior including:

   * Handling of valid Span events

   * Skipping invalid spans

   * Enforcement that only Span events are supported
   
Validation: 
* Unit tests cover both positive and negative paths.

* Uses consistent span test files already used elsewhere in the codebase.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
