### PR TITLE
Add otlp proto trace output codec

### DIFF
--- a/data-prepper-plugins/otel-proto-common/build.gradle
+++ b/data-prepper-plugins/otel-proto-common/build.gradle
@@ -12,6 +12,8 @@ test {
 }
 
 dependencies {
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
     implementation project(':data-prepper-api')
     implementation libs.opentelemetry.proto
     implementation libs.protobuf.util

--- a/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OtlpTraceOutputCodec.java
+++ b/data-prepper-plugins/otel-proto-common/src/main/java/org/opensearch/dataprepper/plugins/otel/codec/OtlpTraceOutputCodec.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.otel.codec;
+
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import io.opentelemetry.proto.trace.v1.ResourceSpans;
+import lombok.NonNull;
+import org.apache.commons.codec.DecoderException;
+import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
+import org.opensearch.dataprepper.model.codec.OutputCodec;
+import org.opensearch.dataprepper.model.event.Event;
+import org.opensearch.dataprepper.model.sink.OutputCodecContext;
+import org.opensearch.dataprepper.model.trace.Span;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.OutputStream;
+
+/**
+ * An implementation of {@link OutputCodec} that converts {@link Span} events
+ * into OpenTelemetry Protocol (OTLP) binary format using protobuf.
+ * <p>
+ * This codec is primarily intended for use with trace data that will be
+ * forwarded to systems such as AWS X-Ray via OTLP.
+ */
+@DataPrepperPlugin(name = "otlp_trace", pluginType = OutputCodec.class)
+public class OtlpTraceOutputCodec implements OutputCodec {
+
+    private static final Logger LOG = LoggerFactory.getLogger(OtlpTraceOutputCodec.class);
+    private static final String OTLP_EXTENSION = "pb";
+
+    private final OTelProtoStandardCodec.OTelProtoEncoder encoder = new OTelProtoStandardCodec.OTelProtoEncoder();
+
+    /**
+     * Initializes the output stream. No-op for OTLP format.
+     *
+     * @param outputStream The output stream to write to.
+     * @param event The event (not used).
+     * @param context The codec context (not used).
+     */
+    @Override
+    public void start(final OutputStream outputStream, final Event event, final OutputCodecContext context) {
+        // No-op for OTLP format
+    }
+
+    /**
+     * Writes a single {@link Span} event to the output stream in OTLP binary format.
+     *
+     * @param event The event to encode. Must be of type {@link Span}.
+     * @param outputStream The stream to which the encoded bytes will be written.
+     */
+    @Override
+    public void writeEvent(@NonNull final Event event, @NonNull final OutputStream outputStream) {
+        if (!(event instanceof Span)) {
+            throw new IllegalArgumentException("OtlpTraceOutputCodec only supports Span events");
+        }
+
+        final Span span = (Span) event;
+        try {
+            final ResourceSpans resourceSpans = encoder.convertToResourceSpans(span);
+            final ExportTraceServiceRequest request = ExportTraceServiceRequest.newBuilder()
+                    .addResourceSpans(resourceSpans)
+                    .build();
+
+            outputStream.write(request.toByteArray());
+        } catch (final DecoderException e) {
+            LOG.warn("Skipping invalid span with ID [{}] due to decoding error.", span.getSpanId(), e);
+        } catch (final Exception e) {
+            LOG.error("Unexpected error while writing span with ID [{}] to OTLP output.", span.getSpanId(), e);
+        }
+    }
+
+    /**
+     * Finalizes the output stream. No-op for OTLP format.
+     *
+     * @param outputStream The output stream to finalize.
+     */
+    @Override
+    public void complete(final OutputStream outputStream) {
+        // No-op for OTLP format
+    }
+
+    /**
+     * Returns the file extension used by this codec.
+     * In this case, "pb" for protobuf binary format.
+     *
+     * @return The string "pb".
+     */
+    @Override
+    public String getExtension() {
+        return OTLP_EXTENSION;
+    }
+}

--- a/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OtlpTraceOutputCodecTest.java
+++ b/data-prepper-plugins/otel-proto-common/src/test/java/org/opensearch/dataprepper/plugins/otel/codec/OtlpTraceOutputCodecTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.otel.codec;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.event.JacksonEvent;
+import org.opensearch.dataprepper.model.sink.OutputCodecContext;
+import org.opensearch.dataprepper.model.trace.DefaultTraceGroupFields;
+import org.opensearch.dataprepper.model.trace.JacksonSpan;
+import org.opensearch.dataprepper.model.trace.Span;
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OtlpTraceOutputCodecTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String TEST_SPAN_EVENT_JSON_FILE = "test-span-event.json";
+
+    private OtlpTraceOutputCodec codec;
+
+    @BeforeEach
+    void setup() {
+        codec = new OtlpTraceOutputCodec();
+    }
+
+    private Span buildSpanFromTestFile(String fileName, String traceIdOverride) {
+        try (InputStream inputStream = Objects.requireNonNull(
+                getClass().getClassLoader().getResourceAsStream(fileName))) {
+
+            final Map<String, Object> spanMap = OBJECT_MAPPER.readValue(inputStream, new TypeReference<>() {});
+            final JacksonSpan.Builder builder = JacksonSpan.builder()
+                    .withTraceId(traceIdOverride != null ? traceIdOverride : (String) spanMap.get("traceId"))
+                    .withSpanId((String) spanMap.get("spanId"))
+                    .withParentSpanId((String) spanMap.get("parentSpanId"))
+                    .withTraceState((String) spanMap.get("traceState"))
+                    .withName((String) spanMap.get("name"))
+                    .withKind((String) spanMap.get("kind"))
+                    .withDurationInNanos(((Number) spanMap.get("durationInNanos")).longValue())
+                    .withStartTime((String) spanMap.get("startTime"))
+                    .withEndTime((String) spanMap.get("endTime"))
+                    .withTraceGroup((String) spanMap.get("traceGroup"));
+
+            final Map<String, Object> traceGroupFieldsMap = (Map<String, Object>) spanMap.get("traceGroupFields");
+            if (traceGroupFieldsMap != null) {
+                builder.withTraceGroupFields(DefaultTraceGroupFields.builder()
+                        .withStatusCode((Integer) traceGroupFieldsMap.getOrDefault("statusCode", 0))
+                        .withEndTime((String) spanMap.get("endTime"))
+                        .withDurationInNanos(((Number) spanMap.get("durationInNanos")).longValue())
+                        .build());
+            }
+
+            return builder.build();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load span from file", e);
+        }
+    }
+
+    @Test
+    void testWriteEvent_withValidSpanFromTestFile_writesSuccessfully() throws Exception {
+        final Span span = buildSpanFromTestFile(TEST_SPAN_EVENT_JSON_FILE, null);
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        codec.start(outputStream, span, new OutputCodecContext());
+        codec.writeEvent(span, outputStream);
+        codec.complete(outputStream);
+
+        final byte[] bytes = outputStream.toByteArray();
+        assertThat(bytes).isNotEmpty();
+
+        final ExportTraceServiceRequest request = ExportTraceServiceRequest.parseFrom(bytes);
+        assertThat(request.getResourceSpansCount()).isGreaterThan(0);
+    }
+
+    @Test
+    void testWriteEvent_withBadTraceId_logsAndSkips() throws Exception {
+        final Span span = buildSpanFromTestFile(TEST_SPAN_EVENT_JSON_FILE,"bad-trace-id" );
+
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        codec.writeEvent(span, outputStream);
+
+        // Since traceId is invalid hex, it will trigger DecoderException
+        assertThat(outputStream.toByteArray()).isEmpty(); // nothing written
+    }
+
+    @Test
+    void testWriteEvent_withNonSpanEvent_throwsException() {
+        final JacksonEvent nonSpanEvent = JacksonEvent.builder()
+                .withEventType("fake")
+                .withData(Map.of("key", "value"))
+                .build();
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        assertThatThrownBy(() -> codec.writeEvent(nonSpanEvent, outputStream))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("OtlpTraceOutputCodec only supports Span events");
+    }
+
+    @Test
+    void testWriteEvent_withNullEvent_throwsNullPointerException() {
+        final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        assertThatThrownBy(() -> codec.writeEvent(null, outputStream))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("event is marked non-null but is null");
+    }
+
+    @Test
+    void testWriteEvent_withNullOutputStream_throwsNullPointerException() {
+        final Span span = buildSpanFromTestFile(TEST_SPAN_EVENT_JSON_FILE, null);
+
+        assertThatThrownBy(() -> codec.writeEvent(span, null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("outputStream is marked non-null but is null");
+    }
+}


### PR DESCRIPTION
### Description
* OtelProtoTraceOutputCodec:
A new OutputCodec implementation that serializes Span events into OTLP-compatible ExportTraceServiceRequest Protobuf messages.

* OtelProtoTraceOutputCodecTest:
Unit tests validating the codec’s behavior including:

  * Handling of valid Span events

  * Skipping invalid spans

  * Enforcement that only Span events are supported

Validation:

* Unit tests cover both positive and negative paths.

* Uses consistent span test files already used elsewhere in the codebase.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [ ] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
