### PR TITLE
Add XRayOTLPSink and XRayOtlpHttpSender for sending OTLP trace data to AWS X-Ray

### DIFF
--- a/data-prepper-plugins/xray-otlp-sink/build.gradle
+++ b/data-prepper-plugins/xray-otlp-sink/build.gradle
@@ -18,11 +18,14 @@ dependencies {
     implementation 'software.amazon.awssdk:auth:2.28.23'
     implementation 'software.amazon.awssdk:sts:2.28.23'
     implementation 'software.amazon.awssdk:regions:2.28.23'
+    implementation("software.amazon.awssdk:http-client-spi")
+    implementation("software.amazon.awssdk:apache-client")
 
     compileOnly 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
 
     implementation project(':data-prepper-api')
+    implementation project(':data-prepper-plugins:otel-proto-common')
     implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'

--- a/data-prepper-plugins/xray-otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/configuration/XRayOTLPSinkConfig.java
+++ b/data-prepper-plugins/xray-otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/configuration/XRayOTLPSinkConfig.java
@@ -7,7 +7,10 @@ package org.opensearch.dataprepper.plugins.sink.xrayotlp.configuration;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import software.amazon.awssdk.regions.Region;
 
 /**
@@ -18,7 +21,10 @@ import software.amazon.awssdk.regions.Region;
  *
  * @since 2.6
  */
+@Getter
 @Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class XRayOTLPSinkConfig {
     /**
      * AWS configuration for X-Ray access.

--- a/data-prepper-plugins/xray-otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/http/XRayOtlpHttpSender.java
+++ b/data-prepper-plugins/xray-otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/http/XRayOtlpHttpSender.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.xrayotlp.http;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+
+import java.io.ByteArrayInputStream;
+
+/**
+ * Responsible for sending signed OTLP Protobuf trace data to AWS X-Ray OTLP endpoint.
+ * This class uses AWS SDK's HTTP client to send the request signed using AWS SigV4.
+ */
+public class XRayOtlpHttpSender implements AutoCloseable {
+
+    private static final Logger LOG = LoggerFactory.getLogger(XRayOtlpHttpSender.class);
+
+    private final SigV4Signer signer;
+    private final SdkHttpClient httpClient;
+
+    /**
+     * Constructs a new OtlpHttpSender.
+     *
+     * @param signer     The SigV4Signer used to sign HTTP requests.
+     * @param httpClient The AWS SDK HTTP client used to send signed requests.
+     */
+    public XRayOtlpHttpSender(final SigV4Signer signer, final SdkHttpClient httpClient) {
+        this.signer = signer;
+        this.httpClient = httpClient;
+    }
+
+    /**
+     * Signs and sends the given OTLP-encoded span payload to the X-Ray OTLP endpoint.
+     *
+     * @param payload The OTLP Protobuf payload to send.
+     */
+    public void send(final byte[] payload) {
+        try {
+            final SdkHttpFullRequest signedRequest = signer.signRequest(payload);
+
+            final HttpExecuteRequest httpRequest = HttpExecuteRequest.builder()
+                    .request(signedRequest)
+                    .contentStreamProvider(() -> new ByteArrayInputStream(payload))
+                    .build();
+
+            final HttpExecuteResponse response = httpClient.prepareRequest(httpRequest).call();
+            final int status = response.httpResponse().statusCode();
+
+            if (status >= 200 && status < 300) {
+                LOG.info("Successfully sent OTLP data to AWS X-Ray. Status: {}", status);
+            } else {
+                LOG.warn("Failed to send OTLP data to AWS X-Ray. Status: {}", status);
+            }
+        } catch (final Exception e) {
+            LOG.error("Error sending OTLP data to AWS X-Ray", e);
+        }
+    }
+
+    /**
+     * Closes the underlying HTTP client to release resources.
+     */
+    @Override
+    public void close() {
+        httpClient.close();
+    }
+}

--- a/data-prepper-plugins/xray-otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/XRayOTLPSinkTest.java
+++ b/data-prepper-plugins/xray-otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/XRayOTLPSinkTest.java
@@ -5,35 +5,141 @@
 
 package org.opensearch.dataprepper.plugins.sink.xrayotlp;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.model.codec.OutputCodec;
 import org.opensearch.dataprepper.model.record.Record;
+import org.opensearch.dataprepper.model.trace.DefaultTraceGroupFields;
+import org.opensearch.dataprepper.model.trace.JacksonSpan;
 import org.opensearch.dataprepper.model.trace.Span;
+import org.opensearch.dataprepper.plugins.sink.xrayotlp.http.XRayOtlpHttpSender;
 
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 class XRayOTLPSinkTest {
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String TEST_SPAN_EVENT_JSON_FILE = "test-span-event.json";
+
+    private OutputCodec mockCodec;
+    private XRayOtlpHttpSender mockSender;
     private XRayOTLPSink sink;
 
     @BeforeEach
     void setUp() {
-        sink = new XRayOTLPSink();
+        mockCodec = mock(OutputCodec.class);
+        mockSender = mock(XRayOtlpHttpSender.class);
+        sink = new XRayOTLPSink(mockCodec, mockSender);
+    }
+
+    private Span buildSpanFromTestFile(String fileName, String traceIdOverride) {
+        try (InputStream inputStream = Objects.requireNonNull(
+                getClass().getClassLoader().getResourceAsStream(fileName))) {
+
+            final Map<String, Object> spanMap = OBJECT_MAPPER.readValue(inputStream, new TypeReference<>() {});
+            final JacksonSpan.Builder builder = JacksonSpan.builder()
+                    .withTraceId(traceIdOverride != null ? traceIdOverride : (String) spanMap.get("traceId"))
+                    .withSpanId((String) spanMap.get("spanId"))
+                    .withParentSpanId((String) spanMap.get("parentSpanId"))
+                    .withTraceState((String) spanMap.get("traceState"))
+                    .withName((String) spanMap.get("name"))
+                    .withKind((String) spanMap.get("kind"))
+                    .withDurationInNanos(((Number) spanMap.get("durationInNanos")).longValue())
+                    .withStartTime((String) spanMap.get("startTime"))
+                    .withEndTime((String) spanMap.get("endTime"))
+                    .withTraceGroup((String) spanMap.get("traceGroup"));
+
+            final Map<String, Object> traceGroupFieldsMap = (Map<String, Object>) spanMap.get("traceGroupFields");
+            if (traceGroupFieldsMap != null) {
+                builder.withTraceGroupFields(DefaultTraceGroupFields.builder()
+                        .withStatusCode((Integer) traceGroupFieldsMap.getOrDefault("statusCode", 0))
+                        .withEndTime((String) spanMap.get("endTime"))
+                        .withDurationInNanos(((Number) spanMap.get("durationInNanos")).longValue())
+                        .build());
+            }
+
+            return builder.build();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to load span from file", e);
+        }
+    }
+
+    @Test
+    void testOutput_sendsDataToXRay_onSuccessResponse() throws Exception {
+        final Span span = buildSpanFromTestFile(TEST_SPAN_EVENT_JSON_FILE, "bad-trace-id");
+        Record<Span> record = new Record<>(span);
+
+        doAnswer(invocation -> {
+            OutputStream out = invocation.getArgument(1);
+            out.write("dummy-otlp-payload".getBytes());
+            return null;
+        }).when(mockCodec).writeEvent(eq(span), any());
+
+        doNothing().when(mockSender).send(eq("dummy-otlp-payload".getBytes()));
+
+        sink.output(Collections.singletonList(record));
+
+        verify(mockCodec).writeEvent(eq(span), any());
+        verify(mockSender).send(eq("dummy-otlp-payload".getBytes()));
+    }
+
+    @Test
+    void testOutput_handlesException_gracefully() throws Exception {
+        Span span = mock(Span.class);
+        Record<Span> record = new Record<>(span);
+
+        doThrow(new RuntimeException("codec error")).when(mockCodec).writeEvent(eq(span), any());
+
+        sink.output(Collections.singletonList(record));
+
+        verify(mockCodec).writeEvent(eq(span), any());
+        verifyNoInteractions(mockSender);
+    }
+
+    @Test
+    void testOutput_senderThrowsException_isHandledGracefully() throws Exception {
+        final Span span = buildSpanFromTestFile(TEST_SPAN_EVENT_JSON_FILE, "bad-trace-id");
+        Record<Span> record = new Record<>(span);
+
+        doAnswer(invocation -> {
+            OutputStream out = invocation.getArgument(1);
+            out.write("dummy-otlp-payload".getBytes());
+            return null;
+        }).when(mockCodec).writeEvent(eq(span), any());
+
+        doThrow(new RuntimeException("Send failed")).when(mockSender).send(any());
+
+        assertDoesNotThrow(() -> sink.output(Collections.singletonList(record)));
+
+        verify(mockCodec).writeEvent(eq(span), any());
+        verify(mockSender).send(any());
+    }
+
+    @Test
+    void testOutput_withNullRecordList_doesNothing() {
+        assertDoesNotThrow(() -> sink.output(null));
+        verifyNoInteractions(mockCodec, mockSender);
+    }
+
+    @Test
+    void testOutput_withEmptyRecordList_doesNothing() {
+        assertDoesNotThrow(() -> sink.output(Collections.emptyList()));
+        verifyNoInteractions(mockCodec, mockSender);
     }
 
     @Test
     void testInitialize_doesNotThrow() {
         assertDoesNotThrow(() -> sink.initialize());
-    }
-
-    @Test
-    void testOutput_printsRecordData() {
-        final Span mockSpan = mock(Span.class);
-        final Record<Span> record = new Record<>(mockSpan);
-        assertDoesNotThrow(() -> sink.output(Collections.singletonList(record)));
     }
 
     @Test

--- a/data-prepper-plugins/xray-otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/configuration/XRayOTLPSinkConfigTest.java
+++ b/data-prepper-plugins/xray-otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/configuration/XRayOTLPSinkConfigTest.java
@@ -9,6 +9,8 @@ import software.amazon.awssdk.regions.Region;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 
 class XRayOTLPSinkConfigTest {
     @Test
@@ -30,5 +32,19 @@ class XRayOTLPSinkConfigTest {
         assertThat(config.getAwsRegion(), equalTo(Region.of(expectedRegion)));
         assertThat(config.getStsRoleArn(), equalTo(expectedRoleArn));
         assertThat(config.getStsExternalId(), equalTo(expectedExternalId));
+    }
+
+    @Test
+    void testDefaultConstructorAndSetters() {
+        final XRayOTLPSinkConfig config = new XRayOTLPSinkConfig();
+        assertThat(config, notNullValue());
+    }
+
+    @Test
+    void testBuilder_withNullAwsAuthConfig() {
+        XRayOTLPSinkConfig config = XRayOTLPSinkConfig.builder()
+                .awsAuthenticationConfiguration(null)
+                .build();
+        assertThat(config.getAwsAuthenticationConfiguration(), nullValue());
     }
 }

--- a/data-prepper-plugins/xray-otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/http/XRayOtlpHttpSenderTest.java
+++ b/data-prepper-plugins/xray-otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/xrayotlp/http/XRayOtlpHttpSenderTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.xrayotlp.http;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.http.ExecutableHttpRequest;
+import software.amazon.awssdk.http.HttpExecuteRequest;
+import software.amazon.awssdk.http.HttpExecuteResponse;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.SdkHttpFullRequest;
+import software.amazon.awssdk.http.SdkHttpResponse;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class XRayOtlpHttpSenderTest {
+
+    private SigV4Signer mockSigner;
+    private SdkHttpClient mockHttpClient;
+    private XRayOtlpHttpSender sender;
+
+    @BeforeEach
+    void setUp() {
+        mockSigner = mock(SigV4Signer.class);
+        mockHttpClient = mock(SdkHttpClient.class);
+        sender = new XRayOtlpHttpSender(mockSigner, mockHttpClient);
+    }
+
+    @Test
+    void testSend_successfulRequest_logsInfo() throws Exception {
+        byte[] payload = "test-payload".getBytes();
+
+        SdkHttpFullRequest signedRequest = mock(SdkHttpFullRequest.class);
+        when(mockSigner.signRequest(payload)).thenReturn(signedRequest);
+
+        HttpExecuteResponse mockResponse = mock(HttpExecuteResponse.class);
+        when(mockResponse.httpResponse()).thenReturn(SdkHttpResponse.builder().statusCode(200).build());
+
+        ExecutableHttpRequest executableRequest = mock(ExecutableHttpRequest.class);
+        when(executableRequest.call()).thenReturn(mockResponse);
+        when(mockHttpClient.prepareRequest(any(HttpExecuteRequest.class))).thenReturn(executableRequest);
+
+        assertDoesNotThrow(() -> sender.send(payload));
+
+        verify(mockSigner).signRequest(payload);
+        verify(mockHttpClient).prepareRequest(any(HttpExecuteRequest.class));
+    }
+
+    @Test
+    void testSend_httpError_logsWarning() throws Exception {
+        byte[] payload = "test-payload".getBytes();
+
+        SdkHttpFullRequest signedRequest = mock(SdkHttpFullRequest.class);
+        when(mockSigner.signRequest(payload)).thenReturn(signedRequest);
+
+        HttpExecuteResponse mockResponse = mock(HttpExecuteResponse.class);
+        when(mockResponse.httpResponse()).thenReturn(SdkHttpResponse.builder().statusCode(500).build());
+
+        ExecutableHttpRequest executableRequest = mock(ExecutableHttpRequest.class);
+        when(executableRequest.call()).thenReturn(mockResponse);
+        when(mockHttpClient.prepareRequest(any(HttpExecuteRequest.class))).thenReturn(executableRequest);
+
+        sender.send(payload);
+
+        verify(mockSigner).signRequest(payload);
+        verify(mockHttpClient).prepareRequest(any(HttpExecuteRequest.class));
+    }
+
+    @Test
+    void testSend_exceptionDuringSend_logsError() throws Exception {
+        byte[] payload = "test-payload".getBytes();
+
+        when(mockSigner.signRequest(payload)).thenThrow(new RuntimeException("signing failed"));
+
+        assertDoesNotThrow(() -> sender.send(payload));
+        verify(mockSigner).signRequest(payload);
+    }
+
+    @Test
+    void testClose_closesHttpClient() throws IOException {
+        sender.close();
+        verify(mockHttpClient).close();
+    }
+}

--- a/data-prepper-plugins/xray-otlp-sink/src/test/resources/test-span-event.json
+++ b/data-prepper-plugins/xray-otlp-sink/src/test/resources/test-span-event.json
@@ -1,0 +1,23 @@
+{
+  "traceId": "ffa576d321173ac6cef3601c8f4bde75",
+  "spanId": "085ac082ffcfbf8d",
+  "traceState": "TRACE_STATE_1",
+  "kind": "SPAN_KIND_CLIENT",
+  "traceGroupFields": {
+    "endTime": "2020-08-20T05:40:43.217170200Z",
+    "durationInNanos": 49160000,
+    "statusCode": 1
+  },
+  "name": "TRACE_1_ROOT_SPAN",
+  "traceGroup": "TRACE_1_ROOT_SPAN",
+  "startTime": "2020-08-20T05:40:43.168010200Z",
+  "durationInNanos": 49160000,
+  "endTime": "2020-08-20T05:40:43.217170200Z",
+  "parentSpanId": "",
+  "attributes": {},
+  "droppedAttributesCount": 0,
+  "links": [],
+  "droppedLinksCount": 0,
+  "events": [],
+  "droppedEventsCount": 0
+}


### PR DESCRIPTION
### Description

- Implement XRayOTLPSink to handle serialized Span records and send them to AWS X-Ray
- Introduce OtlpHttpSender helper class for HTTP request handling with SigV4 signing
- Use ApacheHttpClient for sending requests
- Add comprehensive unit tests 

### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
