### PR TITLE
feature: Add PluginMetrics instrumentation for OTLP delivery and throughput

### DIFF
--- a/data-prepper-plugins/otlp-sink/build.gradle
+++ b/data-prepper-plugins/otlp-sink/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     // Data Prepper Projects
     implementation project(':data-prepper-api')
     implementation project(':data-prepper-plugins:otel-proto-common')
+    implementation 'io.micrometer:micrometer-core'
 
     // Unit Testing
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.1'

--- a/data-prepper-plugins/otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/otlp/OtlpSink.java
+++ b/data-prepper-plugins/otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/otlp/OtlpSink.java
@@ -9,6 +9,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.opentelemetry.proto.collector.trace.v1.ExportTraceServiceRequest;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import org.jetbrains.annotations.Nullable;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPlugin;
 import org.opensearch.dataprepper.model.annotations.DataPrepperPluginConstructor;
 import org.opensearch.dataprepper.model.record.Record;
@@ -17,10 +18,13 @@ import org.opensearch.dataprepper.model.trace.Span;
 import org.opensearch.dataprepper.plugins.otel.codec.OTelProtoStandardCodec;
 import org.opensearch.dataprepper.plugins.sink.otlp.configuration.OtlpSinkConfig;
 import org.opensearch.dataprepper.plugins.sink.otlp.http.OtlpHttpSender;
+import org.opensearch.dataprepper.plugins.sink.otlp.metrics.OtlpSinkMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -42,6 +46,7 @@ public class OtlpSink implements Sink<Record<Span>> {
     private final int batchSize;
     private final OtlpHttpSender httpSender;
     private final OTelProtoStandardCodec.OTelProtoEncoder encoder;
+    private final OtlpSinkMetrics sinkMetrics;
 
     /**
      * Constructor for the OTLPSink plugin.
@@ -49,8 +54,8 @@ public class OtlpSink implements Sink<Record<Span>> {
      * @param config the configuration for the OTLP sink
      */
     @DataPrepperPluginConstructor
-    public OtlpSink(@Nonnull final OtlpSinkConfig config) {
-        this(config, null, null);
+    public OtlpSink(@Nonnull final OtlpSinkConfig config, @Nonnull final PluginMetrics pluginMetrics) {
+        this(config, pluginMetrics, null, null);
     }
 
     /**
@@ -61,12 +66,13 @@ public class OtlpSink implements Sink<Record<Span>> {
      * @param httpSender the HTTP sender to use
      */
     @VisibleForTesting
-    OtlpSink(@Nonnull final OtlpSinkConfig config, final OTelProtoStandardCodec.OTelProtoEncoder encoder, final OtlpHttpSender httpSender) {
+    OtlpSink(@Nonnull final OtlpSinkConfig config, @Nonnull final PluginMetrics pluginMetrics, final OTelProtoStandardCodec.OTelProtoEncoder encoder, final OtlpHttpSender httpSender) {
         this.batchSize = config.getBatchSize();
+        this.sinkMetrics = new OtlpSinkMetrics(pluginMetrics);
 
         if (encoder == null && httpSender == null) {
             this.encoder = new OTelProtoStandardCodec.OTelProtoEncoder();
-            this.httpSender = new OtlpHttpSender(config);
+            this.httpSender = new OtlpHttpSender(config, sinkMetrics);
         } else {
             this.encoder = encoder;
             this.httpSender = httpSender;
@@ -95,6 +101,8 @@ public class OtlpSink implements Sink<Record<Span>> {
      */
     @Override
     public void output(@Nonnull final Collection<Record<Span>> records) {
+        sinkMetrics.incrementRecordsIn(records.size());
+
         final List<Record<Span>> recordList = new ArrayList<>(records);
         for (int i = 0; i < recordList.size(); i += this.batchSize) {
             final int end = Math.min(i + this.batchSize, recordList.size());
@@ -115,10 +123,18 @@ public class OtlpSink implements Sink<Record<Span>> {
                 final ExportTraceServiceRequest request = ExportTraceServiceRequest.newBuilder()
                         .addAllResourceSpans(resourceSpans)
                         .build();
-                httpSender.send(request.toByteArray());
+                final byte[] payload = request.toByteArray();
+                sinkMetrics.incrementPayloadSize(payload.length);
+
+                httpSender.send(payload);
                 LOG.info("Finished processing {} spans.", resourceSpans.size());
+
+                sinkMetrics.incrementRecordsOut(batch.size());
             } catch (final RuntimeException e) {
                 LOG.error("Unexpected error processing OTLP span batch: {}", e.getMessage(), e);
+
+                sinkMetrics.incrementDroppedRecords(batch.size());
+                sinkMetrics.incrementErrorsCount();
             }
         }
     }
@@ -129,6 +145,7 @@ public class OtlpSink implements Sink<Record<Span>> {
             return encoder.convertToResourceSpans(span);
         } catch (final Exception e) {
             LOG.warn("Failed to encode span with ID [{}], skipping.", span.getSpanId(), e);
+            sinkMetrics.incrementErrorsCount();
             return null;
         }
     }
@@ -153,12 +170,27 @@ public class OtlpSink implements Sink<Record<Span>> {
     }
 
     /**
-     * Updates internal latency metrics using the received records.
+     * Records the latency between when each span originally started (as specified in the span's start time)
+     * and when it was received by the sink (i.e., when this method is called).
+     * <p>
+     * This measures end-to-end ingestion latency from the span's source to the sink.
+     * It does not include any processing or export latency within the sink itself.
      *
-     * @param events Collection of records used for latency tracking.
+     * @param events A collection of spans received by the sink.
      */
     @Override
     public void updateLatencyMetrics(@Nonnull final Collection<Record<Span>> events) {
-        // TODO: Implement latency tracking with PluginMetrics
+        final Instant now = Instant.now();
+
+        for (final Record<Span> record : events) {
+            try {
+                final Instant startTime = Instant.parse(record.getData().getStartTime());
+                final long durationMillis = Duration.between(startTime, now).toMillis();
+                sinkMetrics.recordDeliveryLatency(durationMillis);
+            } catch (final Exception e) {
+                LOG.warn("Failed to parse startTime: {}", record.getData().getStartTime(), e);
+                sinkMetrics.incrementErrorsCount();
+            }
+        }
     }
 }

--- a/data-prepper-plugins/otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/otlp/metrics/OtlpSinkMetrics.java
+++ b/data-prepper-plugins/otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/otlp/metrics/OtlpSinkMetrics.java
@@ -1,0 +1,74 @@
+/*
+ *  Copyright OpenSearch Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.otlp.metrics;
+
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+
+import javax.annotation.Nonnull;
+
+/**
+ * Metrics class for the otlp-sink
+ */
+public class OtlpSinkMetrics {
+
+    private final PluginMetrics pluginMetrics;
+
+    /**
+     * Constructor for OtlpSinkMetrics
+     *
+     * @param pluginMetrics The plugin metrics instance
+     */
+    public OtlpSinkMetrics(@Nonnull final PluginMetrics pluginMetrics) {
+        this.pluginMetrics = pluginMetrics;
+    }
+
+    public void incrementRecordsIn(long count) {
+        pluginMetrics.counter("recordsIn").increment(count);
+    }
+
+    public void incrementRecordsOut(long count) {
+        pluginMetrics.counter("recordsOut").increment(count);
+    }
+
+    public void incrementDroppedRecords(long count) {
+        pluginMetrics.counter("droppedRecords").increment(count);
+    }
+
+    public void incrementErrorsCount() {
+        pluginMetrics.counter("errorsCount").increment(1);
+    }
+
+    public void incrementPayloadSize(long bytes) {
+        pluginMetrics.summary("payloadSize").record(bytes);
+    }
+
+    public void recordDeliveryLatency(long durationMillis) {
+        pluginMetrics.summary("deliveryLatency").record(durationMillis);
+    }
+
+    public void recordHttpLatency(long durationMillis) {
+        pluginMetrics.summary("httpLatency").record(durationMillis);
+    }
+
+    public void incrementRetriesCount() {
+        pluginMetrics.counter("retriesCount").increment(1);
+    }
+
+    public void incrementRejectedSpansCount(long count) {
+        pluginMetrics.counter("rejectedSpansCount").increment(count);
+    }
+
+    /**
+     * Records the response code in the metrics.
+     * Group response codes by category: 2xx, 4xx, 5xx, etc.
+     *
+     * @param statusCode The HTTP response code.
+     */
+    public void recordResponseCode(final int statusCode) {
+        String codeCategory = (statusCode / 100) + "xx";
+        pluginMetrics.counter("http_" + codeCategory + "_responses").increment();
+    }
+}

--- a/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/http/OtlpHttpSenderTest.java
+++ b/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/http/OtlpHttpSenderTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.plugins.sink.otlp.configuration.OtlpSinkConfig;
+import org.opensearch.dataprepper.plugins.sink.otlp.metrics.OtlpSinkMetrics;
 import software.amazon.awssdk.http.SdkHttpFullRequest;
 import software.amazon.awssdk.regions.Region;
 
@@ -54,6 +55,7 @@ class OtlpHttpSenderTest {
     private SigV4Signer mockSigner;
     private OkHttpClient mockHttpClient;
     private Sleeper mockSleeper;
+    private OtlpSinkMetrics mockSinkMetrics;
     private OtlpHttpSender target;
 
     @BeforeEach
@@ -68,8 +70,9 @@ class OtlpHttpSenderTest {
         mockSigner = mock(SigV4Signer.class);
         mockHttpClient = mock(OkHttpClient.class);
         mockSleeper = mock(Sleeper.class);
+        mockSinkMetrics = mock(OtlpSinkMetrics.class);
 
-        target = new OtlpHttpSender(mockConfig, mockSigner, mockHttpClient, mockSleeper);
+        target = new OtlpHttpSender(mockConfig, mockSinkMetrics, mockSigner, mockHttpClient, mockSleeper);
     }
 
     @AfterEach
@@ -225,7 +228,7 @@ class OtlpHttpSenderTest {
 
         doThrow(new InterruptedException("interrupted")).when(mockSleeper).sleep(anyInt());
 
-        target = new OtlpHttpSender(mockConfig, mockSigner, mockHttpClient, mockSleeper);
+        target = new OtlpHttpSender(mockConfig, mockSinkMetrics, mockSigner, mockHttpClient, mockSleeper);
 
         final RuntimeException thrown = assertThrows(RuntimeException.class, () ->
                 target.send(PAYLOAD)
@@ -390,7 +393,7 @@ class OtlpHttpSenderTest {
 
     @Test
     void testDefaultConstructorInitializesDefaults() {
-        target = new OtlpHttpSender(mockConfig);
+        target = new OtlpHttpSender(mockConfig, mockSinkMetrics);
 
         // Reflection to assert internal fields (not great, but useful for unit validation)
         assertNotNull(getPrivateField(target, "signer"));

--- a/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/metrics/OtlpSinkMetricsTest.java
+++ b/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/metrics/OtlpSinkMetricsTest.java
@@ -1,0 +1,97 @@
+/*
+ *  Copyright OpenSearch Contributors
+ *  SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.opensearch.dataprepper.plugins.sink.otlp.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.DistributionSummary;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.opensearch.dataprepper.metrics.PluginMetrics;
+
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class OtlpSinkMetricsTest {
+
+    private PluginMetrics pluginMetrics;
+    private Counter counterMock;
+    private DistributionSummary summaryMock;
+    private OtlpSinkMetrics sinkMetrics;
+
+    @BeforeEach
+    void setUp() {
+        pluginMetrics = mock(PluginMetrics.class);
+        counterMock = mock(Counter.class);
+        summaryMock = mock(DistributionSummary.class);
+
+        when(pluginMetrics.counter(anyString())).thenReturn(counterMock);
+        when(pluginMetrics.summary(anyString())).thenReturn(summaryMock);
+
+        sinkMetrics = new OtlpSinkMetrics(pluginMetrics);
+    }
+
+    @Test
+    void testIncrementRecordsIn() {
+        sinkMetrics.incrementRecordsIn(3);
+        verify(counterMock).increment(3);
+    }
+
+    @Test
+    void testIncrementRecordsOut() {
+        sinkMetrics.incrementRecordsOut(2);
+        verify(counterMock).increment(2);
+    }
+
+    @Test
+    void testIncrementDroppedRecords() {
+        sinkMetrics.incrementDroppedRecords(1);
+        verify(counterMock).increment(1);
+    }
+
+    @Test
+    void testIncrementErrorsCount() {
+        sinkMetrics.incrementErrorsCount();
+        verify(counterMock).increment(1);
+    }
+
+    @Test
+    void testIncrementPayloadSize() {
+        sinkMetrics.incrementPayloadSize(1024);
+        verify(summaryMock).record(1024);
+    }
+
+    @Test
+    void testRecordDeliveryLatency() {
+        sinkMetrics.recordDeliveryLatency(150);
+        verify(summaryMock).record(150);
+    }
+
+    @Test
+    void testRecordHttpLatency() {
+        sinkMetrics.recordHttpLatency(150);
+        verify(summaryMock).record(150);
+    }
+
+    @Test
+    void testIncrementRetriesCount() {
+        sinkMetrics.incrementRetriesCount();
+        verify(counterMock).increment(1);
+    }
+
+    @Test
+    void testIncrementRejectedSpansCount() {
+        sinkMetrics.incrementRejectedSpansCount(5);
+        verify(counterMock).increment(5);
+    }
+
+    @Test
+    void testRecordResponseCode() {
+        sinkMetrics.recordResponseCode(200);
+        verify(pluginMetrics).counter("http_2xx_responses");
+    }
+}

--- a/data-prepper-plugins/otlp-sink/src/test/resources/data-prepper-config.yaml
+++ b/data-prepper-plugins/otlp-sink/src/test/resources/data-prepper-config.yaml
@@ -1,1 +1,3 @@
 ssl: false
+metricRegistries:
+  - CloudWatch

--- a/data-prepper-plugins/otlp-sink/src/test/resources/pipelines.yaml
+++ b/data-prepper-plugins/otlp-sink/src/test/resources/pipelines.yaml
@@ -1,4 +1,4 @@
-otel_trace_source_to_xray:
+otlp_pipeline:
   source:
     otel_trace_source:
       ssl: false


### PR DESCRIPTION
### Description
- Introduced OtlpSinkMetrics class to track key metrics:
    - recordsIn, recordsOut, droppedRecords
    - payloadSize, deliveryLatency
    - retriesCount, rejectedSpansCount, errorsCount
    - response code categorization (e.g., http_2xx_responses)
- Added instrumentation in OtlpSink and OtlpHttpSender
- Metrics follow the format: output-pipeline_otlp_sink_METRIC_NAME
- Included unit tests for output() and updateLatencyMetrics(), including error handling

Helps validate plugin health, delivery reliability, and performance under load.
 
### Issues Resolved
N/A
 
### Check List
- [x] New functionality includes testing.
- [x] New functionality has a documentation issue. Please link to it in this PR.
  - [x] New functionality has javadoc added
- [x] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
