### PR TITLE
fix: use Timer to track latency metrics and correcting latency metric semantics

### DIFF
--- a/data-prepper-plugins/otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/otlp/metrics/OtlpSinkMetrics.java
+++ b/data-prepper-plugins/otlp-sink/src/main/java/org/opensearch/dataprepper/plugins/sink/otlp/metrics/OtlpSinkMetrics.java
@@ -8,6 +8,7 @@ package org.opensearch.dataprepper.plugins.sink.otlp.metrics;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
 
 import javax.annotation.Nonnull;
+import java.time.Duration;
 
 /**
  * Metrics class for the otlp-sink
@@ -46,11 +47,11 @@ public class OtlpSinkMetrics {
     }
 
     public void recordDeliveryLatency(long durationMillis) {
-        pluginMetrics.summary("deliveryLatency").record(durationMillis);
+        pluginMetrics.timer("deliveryLatency").record(Duration.ofMillis(durationMillis));
     }
 
     public void recordHttpLatency(long durationMillis) {
-        pluginMetrics.summary("httpLatency").record(durationMillis);
+        pluginMetrics.timer("httpLatency").record(Duration.ofMillis(durationMillis));
     }
 
     public void incrementRetriesCount() {

--- a/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/OtlpSinkTest.java
+++ b/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/OtlpSinkTest.java
@@ -7,6 +7,7 @@ package org.opensearch.dataprepper.plugins.sink.otlp;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Timer;
 import io.opentelemetry.proto.trace.v1.ResourceSpans;
 import org.apache.commons.codec.DecoderException;
 import org.junit.jupiter.api.AfterEach;
@@ -21,6 +22,7 @@ import org.opensearch.dataprepper.plugins.sink.otlp.http.OtlpHttpSender;
 import software.amazon.awssdk.regions.Region;
 
 import java.io.UnsupportedEncodingException;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -62,6 +64,7 @@ class OtlpSinkTest {
         mockPluginMetrics = mock(PluginMetrics.class);
         when(mockPluginMetrics.counter(anyString())).thenReturn(mock(Counter.class));
         when(mockPluginMetrics.summary(anyString())).thenReturn(mock(DistributionSummary.class));
+        when(mockPluginMetrics.timer(anyString())).thenReturn(mock(Timer.class));
 
         target = new OtlpSink(mockConfig, mockPluginMetrics, mockEncoder, mockSender);
     }
@@ -167,7 +170,7 @@ class OtlpSinkTest {
 
         target.updateLatencyMetrics(events);
 
-        verify(mockPluginMetrics.summary("deliveryLatency"), times(1)).record(any(Double.class));
+        verify(mockPluginMetrics.timer("deliveryLatency"), times(1)).record(any(Duration.class));
     }
 
     @Test

--- a/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/metrics/OtlpSinkMetricsTest.java
+++ b/data-prepper-plugins/otlp-sink/src/test/java/org/opensearch/dataprepper/plugins/sink/otlp/metrics/OtlpSinkMetricsTest.java
@@ -7,9 +7,12 @@ package org.opensearch.dataprepper.plugins.sink.otlp.metrics;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
+import io.micrometer.core.instrument.Timer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.opensearch.dataprepper.metrics.PluginMetrics;
+
+import java.time.Duration;
 
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
@@ -20,6 +23,7 @@ class OtlpSinkMetricsTest {
 
     private PluginMetrics pluginMetrics;
     private Counter counterMock;
+    private Timer timerMock;
     private DistributionSummary summaryMock;
     private OtlpSinkMetrics sinkMetrics;
 
@@ -28,9 +32,11 @@ class OtlpSinkMetricsTest {
         pluginMetrics = mock(PluginMetrics.class);
         counterMock = mock(Counter.class);
         summaryMock = mock(DistributionSummary.class);
+        timerMock = mock(Timer.class);
 
         when(pluginMetrics.counter(anyString())).thenReturn(counterMock);
         when(pluginMetrics.summary(anyString())).thenReturn(summaryMock);
+        when(pluginMetrics.timer(anyString())).thenReturn(timerMock);
 
         sinkMetrics = new OtlpSinkMetrics(pluginMetrics);
     }
@@ -68,13 +74,13 @@ class OtlpSinkMetricsTest {
     @Test
     void testRecordDeliveryLatency() {
         sinkMetrics.recordDeliveryLatency(150);
-        verify(summaryMock).record(150);
+        verify(timerMock).record(Duration.ofMillis(150));
     }
 
     @Test
     void testRecordHttpLatency() {
         sinkMetrics.recordHttpLatency(150);
-        verify(summaryMock).record(150);
+        verify(timerMock).record(Duration.ofMillis(150));
     }
 
     @Test


### PR DESCRIPTION
### Description
Switched `recordHttpLatency` and `recordDeliveryLatency` to use Micrometer's `Timer`
instead of `DistributionSummary`. This aligns with the semantic intent of capturing
latency metrics and enables built-in support for duration-aware units and aggregation
(e.g., sum, count, avg, max) in CloudWatch.

Also updated unit tests to verify Timer interactions using `Duration`.
 
### Issues Resolved
N/A
 
### Check List
- [X] New functionality includes testing.
- [X] New functionality has a documentation issue. Please link to it in this PR.
  - [X] New functionality has javadoc added
- [X] Commits are signed with a real name per the DCO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/data-prepper/blob/main/CONTRIBUTING.md).
